### PR TITLE
Small changes that allow the Skeleton example to run on both iOS and macOS

### DIFF
--- a/foriOS/CaptiveWebView/CaptiveWebView/CaptiveURLHandler.swift
+++ b/foriOS/CaptiveWebView/CaptiveWebView/CaptiveURLHandler.swift
@@ -119,9 +119,15 @@ class CaptiveURLHandler: NSObject, WKURLSchemeHandler, WKScriptMessageHandler {
         // Handy diagnostic code for anybody interested.
         // os_log("main:%@ self:%@", Bundle.main.bundleURL.description,
         //        Bundle(for: type(of: self)).bundleURL.description)
+        #if targetEnvironment(macCatalyst)
+        responseURL = Bundle(for: type(of: self)).bundleURL
+            .appending(pathComponents: [
+                "Resources", "library", requestURL.lastPathComponent])
+        #else
         responseURL = Bundle(for: type(of: self)).bundleURL
             .appending(pathComponents: [
                 "library", requestURL.lastPathComponent])
+        #endif
         // When there was a "WebAssets" group with a directory, it
         // didn't seem to feature in the bundle.
         do {

--- a/foriOS/CaptiveWebView/CaptiveWebView/CaptiveWebView.swift
+++ b/foriOS/CaptiveWebView/CaptiveWebView/CaptiveWebView.swift
@@ -117,11 +117,9 @@ public struct CaptiveWebView {
         let filePaths = CaptiveWebView.WebResource.findFile(name:file)
         var builder = URLComponents()
         builder.scheme = scheme
-        // URL construction on next line ensures that a leading slash is added.
-        builder.path = URL(fileURLWithPath:
-            filePaths.count > 0 ? filePaths[0] : file
-            ).path
-        
+        // Note: if there were multiple files with the same name in different directories this code
+        // picks the first one. This may not be the desired outcome.
+        builder.path = "/" + (filePaths.count > 0 ? filePaths[0] : file)
         webView.load(URLRequest(url:builder.url!))
         return builder.url!
     }

--- a/foriOS/Skeleton/Skeleton.xcodeproj/project.pbxproj
+++ b/foriOS/Skeleton/Skeleton.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		046B7C342347C7990034D246 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		046B7C362347C7990034D246 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		049D5D622348AE24006981C0 /* CaptiveWebView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CaptiveWebView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		679377CC23E821200002AE2D /* Skeleton.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Skeleton.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +77,7 @@
 		046B7C292347C7980034D246 /* Skeleton */ = {
 			isa = PBXGroup;
 			children = (
+				679377CC23E821200002AE2D /* Skeleton.entitlements */,
 				045DC7F523A000C600A553B0 /* UserInterface */,
 				0438B8112348E00A00F5B415 /* MainViewController.swift */,
 				046B7C2A2347C7980034D246 /* AppDelegate.swift */,
@@ -306,7 +308,9 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Skeleton/Skeleton.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_TEAM = S2ZMFGQM93;
 				HEADER_SEARCH_PATHS = "/Users/hawkinsji/Library/Developer/Xcode/DerivedData/Demonstration-emflntfrxvvnbmdvjjiyjgdynbvo/Build/Products/Debug-iphoneos/CaptiveWebView.framework/Headers";
 				INFOPLIST_FILE = Skeleton/Info.plist;
@@ -316,6 +320,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.CaptiveSkeleton;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -326,7 +331,9 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Skeleton/Skeleton.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_TEAM = S2ZMFGQM93;
 				HEADER_SEARCH_PATHS = "/Users/hawkinsji/Library/Developer/Xcode/DerivedData/Demonstration-emflntfrxvvnbmdvjjiyjgdynbvo/Build/Products/Debug-iphoneos/CaptiveWebView.framework/Headers";
 				INFOPLIST_FILE = Skeleton/Info.plist;
@@ -336,6 +343,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.CaptiveSkeleton;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/foriOS/Skeleton/Skeleton/Skeleton.entitlements
+++ b/foriOS/Skeleton/Skeleton/Skeleton.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
These changes are 'production-ready', but they at least describe the code updates that are needed to get captive web view running on macOS.
We could either integrate them in as-is, or keep this as a reference for later.